### PR TITLE
Release v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "bl3_save_edit_ui"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bl3_save_edit_core",

--- a/bl3_save_edit_ui/Cargo.toml
+++ b/bl3_save_edit_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bl3_save_edit_ui"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Release v0.1.4:

- Lootlemon integration in Inventory/Bank tabs - all 499 items from Lootlemon are now available inside the editor with easy searching/importing - huge thanks to the owner of Lootlemon for providing these items, be sure to check out https://www.lootlemon.com/ for more detailed information about the items.
- Added Vehicle tab to allow unlocking of Vehicle Parts/Skins
- Allow reversing the order of your items as they appear in the item list
- Allow changing of backups folder/opening config folder/opening saves folder in the Settings tab
- All Item Levels input now uses "Set" button to apply the levels
- Correctly identify item rarities rather than labelling unkown rarities as legendary. Also added tag "Unique Weapon"
- Item parts info updated - now we use more up to date barrel info.
- Make item parsing more leanient - allow importing item serials that aren't entirely correct but should work fine
- Decrease minimum allowed window size
- Fixed a bug where saving was failing due to invalid filename when creating a backup - now we sanitize the filename before making a backup.
- Fixed a bug where some saves weren't loading due to incorrect assumptions made about playthrough information
- Fixed a bug where changing saves folder did not reflect in the Settings tab
- Fixed a bug where incorrect item name was showing in rare scenarios 
- Fixed a bug where the added current part did not match the available part pressed in rare scenarios
- Fixed a bug where pressing escape whilst searching through Balances/Inventory Data/Manufacturer list meant you could not focus the search box again until you closed the pick list